### PR TITLE
magento-engcom/community-portal#2 Add Jest support to the project

### DIFF
--- a/frontend/__tests__/jest.ts
+++ b/frontend/__tests__/jest.ts
@@ -1,0 +1,5 @@
+describe('jest-test', () => {
+  it('jest should be successfully installed to use TypeScript', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "Simple Crowdsourcing platform based on GitHub",
   "main": "src/app.js",
   "scripts": {
-    "test": "test"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/vrann/crowdsourcing#readme",
   "devDependencies": {
+    "@types/jest": "^22.2.3",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-react-jsx": "^6.24.1",
@@ -29,7 +30,10 @@
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
+    "jest": "^22.4.3",
     "style-loader": "^0.18.2",
+    "ts-jest": "^22.4.6",
+    "typescript": "^2.8.4",
     "url-loader": "^0.5.9",
     "webpack": "^3.5.6"
   },
@@ -42,5 +46,19 @@
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
     "rickshaw": "^1.6.4"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "lib": [
+      "es6",
+      "es2015.promise",
+      "esnext.asynciterable"
+    ]
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,9 @@
     "serverless-http": "^1.5.5"
   },
   "devDependencies": {
-    "jest": "^22.4.3"
+    "jest": "^22.4.3",
+    "@types/jest": "^22.2.3",
+    "ts-jest": "^22.4.6"
   },
   "scripts": {
     "test": "jest"
@@ -22,5 +24,19 @@
   "bugs": {
     "url": "https://github.com/magento/devportal/issues"
   },
-  "homepage": "https://github.com/magento/devportal#readme"
+  "homepage": "https://github.com/magento/devportal#readme",
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  }
 }

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "lib": [
+      "es6",
+      "es2015.promise",
+      "esnext.asynciterable"
+    ]
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
magento-engcom/community-portal#2 Add Jest support to the project

- Add Jest support for TypeScript
- Tests run with npm test
- A folder __tests__ has been created in /frontend