### PR TITLE
magento-engcom/community-portal#177 Investigate DOMException Error during signin

### DIFF
--- a/frontend/src/components/GithubAuthModal.ts
+++ b/frontend/src/components/GithubAuthModal.ts
@@ -59,12 +59,17 @@ class GithubAuthModal {
             reject(new Error('The popup was closed'));
           }
 
-          if (popup.location.href === this.url ||
-            popup.location.pathname === 'blank' ||
-            !popup.location.pathname
-          ) {
+          try {
+            if (popup.location.href === this.url ||
+              popup.location.pathname === 'blank' ||
+              !popup.location.pathname
+            ) {
+              return;
+            }
+          } catch (error) {
             return;
           }
+
           const params = qs.parse(popup.location.search.substr(1)).code;
           resolve(params);
           this.close();


### PR DESCRIPTION
magento-engcom/community-portal#177 Investigate DOMException Error during signin

- [x] When browser tries to access GitHub page, it is blocked. We catch the error and do nothing because it means the user has not returned to the community portal yet