### PR TITLE
magento-engcom/community-portal#273 Remove pledging check

### DIFF
--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -302,7 +302,7 @@ export class ProjectCard extends React.Component<CardProps & DispatchProps, Card
   getPercentage(project: any) {
     const numOfPledgers = Object.keys(project.pledgers).length;
     const { estimated } = this.props.project;
-    return (numOfPledgers / estimated) * 100;
+    return Math.min(100, (numOfPledgers / estimated) * 100);
   }
 
   goDetail() {

--- a/frontend/src/components/ProjectDetails.tsx
+++ b/frontend/src/components/ProjectDetails.tsx
@@ -255,7 +255,7 @@ export class ProjectDetails extends React.Component<ProjectDetailsProps & Dispat
   getPercentage(project: any) {
     const numOfPledgers = Object.keys(project.pledgers).length;
     const { estimated } = this.props.project;
-    return (numOfPledgers / estimated) * 100;
+    return Math.min(100, (numOfPledgers / estimated) * 100);
   }
 
   checkLike(id: string) {

--- a/functions/handlers/user/pledge/handler.ts
+++ b/functions/handlers/user/pledge/handler.ts
@@ -12,16 +12,10 @@ import {
 const dataflows = [
   {
     controller: ProjectController,
-    method: 'checkPledged',
-    target: ProjectResource,
-    methodMap: { checkPledged: 'getById' },
-    validationMap: { checkPledged: 'projectIdOnlySchema' },
-    authDataDependencies: ['user_id'],
-  },
-  {
-    controller: ProjectController,
     method: 'addPledged',
+    validationMap: { addPledged: 'projectIdOnlySchema' },
     target: ProjectResource,
+    authDataDependencies: ['user_id'],
   },
   {
     controller: ProjectController,

--- a/functions/src/controllers/ProjectController/ProjectController.ts
+++ b/functions/src/controllers/ProjectController/ProjectController.ts
@@ -180,7 +180,6 @@ export default class ProjectController implements ProjectControllerInterface {
   // check if pledged would exceed total
   checkPledged(data: any) {
     return (result: any) => {
-      const flag = { will_exceed: false };
       if (result.Item) {
         const { pledged, estimated } = result.Item;
         if (pledged + 1 > estimated) {


### PR DESCRIPTION
magento-engcom/community-portal#273 Remove pledging check

- remove pledge check so that number of pledgers can go above estimated
- adapt progress circle so that 100% is still shown even pledgers exceed estimated